### PR TITLE
simple8b: remove interfaces, use fixed buffer

### DIFF
--- a/simple8b/encoding_test.go
+++ b/simple8b/encoding_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/jwilder/encoding/simple8b"
 )
 
-type valueSetter interface {
-	SetValues(v []uint64)
-}
-
-type byteSetter interface {
-	SetBytes(v []byte)
-}
-
 func Test_Encode_NoValues(t *testing.T) {
 	var in []uint64
 	encoded, _ := simple8b.EncodeAll(in)
@@ -209,7 +201,7 @@ func BenchmarkEncoder(b *testing.B) {
 	enc := simple8b.NewEncoder()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		enc.(valueSetter).SetValues(x)
+		enc.SetValues(x)
 		enc.Bytes()
 		b.SetBytes(int64(len(x)) * 8)
 	}
@@ -247,7 +239,7 @@ func BenchmarkDecoder(b *testing.B) {
 
 	dec := simple8b.NewDecoder(y)
 	for i := 0; i < b.N; i++ {
-		dec.(byteSetter).SetBytes(y)
+		dec.SetBytes(y)
 		j := 0
 		for dec.Next() {
 			j += 1


### PR DESCRIPTION
## Overview

This pull request changes `Encoder` and `Decoder` from interfaces to structs and changes `Decoder.buf` from a `[]uint64` to a fixed length `[240]uint64`. These changes were made to allow inlining of functions and to avoid slice range checks.

### Benchmark

```
benchmark              old ns/op     new ns/op     delta
BenchmarkDecode-4      974           775           -20.43%
BenchmarkDecoder-4     6619          5679          -14.20%

benchmark              old MB/s     new MB/s     speedup
BenchmarkDecode-4      8404.84      10563.97     1.26x
BenchmarkDecoder-4     1237.58      1442.40      1.17x
```