### PR TITLE
Fix panic when simple8b input isn't 64-bit aligned

### DIFF
--- a/simple8b/encoding.go
+++ b/simple8b/encoding.go
@@ -153,7 +153,7 @@ func (d *Decoder) Next() bool {
 		d.read()
 	}
 
-	return len(d.bytes) > 0 || (d.i >= 0 && d.i < d.n)
+	return len(d.bytes) >= 8 || (d.i >= 0 && d.i < d.n)
 }
 
 func (d *Decoder) SetBytes(b []byte) {
@@ -170,7 +170,7 @@ func (d *Decoder) Read() uint64 {
 }
 
 func (d *Decoder) read() {
-	if len(d.bytes) == 0 {
+	if len(d.bytes) < 8 {
 		return
 	}
 

--- a/simple8b/encoding_test.go
+++ b/simple8b/encoding_test.go
@@ -177,6 +177,13 @@ func Test_Encode_ValueTooLarge(t *testing.T) {
 	}
 }
 
+func Test_Decode_NotEnoughBytes(t *testing.T) {
+	dec := simple8b.NewDecoder([]byte{0})
+	if dec.Next() {
+		t.Fatalf("Expected Next to return false but it returned true")
+	}
+}
+
 func BenchmarkEncode(b *testing.B) {
 	total := 0
 	x := make([]uint64, 1024)


### PR DESCRIPTION
Spotted this in the stack trace from [this mailing list post](https://groups.google.com/forum/?pli=1#!topic/influxdb/51jbjEbvYMM).

Might be related to https://github.com/influxdata/influxdb/issues/6468.