### PR TITLE
Reset an existing decoder

### DIFF
--- a/simple8b/encoding.go
+++ b/simple8b/encoding.go
@@ -148,6 +148,13 @@ func NewDecoder(b []byte) *Decoder {
 	}
 }
 
+// New initialies resets d so it can be used with a new stream.
+func (d *Decoder) Reset(b []byte) {
+	d.i, d.n = 0, 0
+	// d.buf does not need re-initialising because it's only read using d.i.
+	d.bytes = b
+}
+
 // Next returns true if there are remaining values to be read.  Successive
 // calls to Next advance the current element pointer.
 func (d *Decoder) Next() bool {

--- a/simple8b/encoding_test.go
+++ b/simple8b/encoding_test.go
@@ -254,3 +254,24 @@ func BenchmarkDecoder(b *testing.B) {
 		b.SetBytes(int64(j * 8))
 	}
 }
+
+var decResult *simple8b.Decoder
+
+func Benchmark_NewDecoder(b *testing.B) {
+	buf := make([]byte, 100)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		decResult = simple8b.NewDecoder(buf[9:])
+	}
+}
+
+func BenchmarkDecoder_New(b *testing.B) {
+	buf := make([]byte, 100)
+	b.ResetTimer()
+	b.ReportAllocs()
+	decResult = simple8b.NewDecoder(buf[9:])
+	for i := 0; i < b.N; i++ {
+		decResult.Reset(buf[9:])
+	}
+}


### PR DESCRIPTION
If you need to decode a lot of streams, it's more efficient to reset an existing `Decoder`, rather than allocating a new one.

```
⇒  gt -run NONE -bench BenchmarkSimple8b_
testing: warning: no tests to run
BenchmarkSimple8b_NewDecoder-4    	 3000000	       457 ns/op	    2048 B/op	       1 allocs/op
BenchmarkSimple8b_Decoder_New-4   	2000000000	         2.00 ns/op	       0 B/op	       0 allocs/op
PASS
```